### PR TITLE
Update WindowsWebClient.cs

### DIFF
--- a/HubspotAPIWrapper/HubspotAPIWrapper/WindowsWebClient.cs
+++ b/HubspotAPIWrapper/HubspotAPIWrapper/WindowsWebClient.cs
@@ -17,6 +17,7 @@ namespace HubspotAPIWrapper
             {
                 var writer = new StreamWriter(request.GetRequestStream());
                 writer.Write(data);
+                writer.Close();
             }
 
 


### PR DESCRIPTION
writer.Close() is needed in order to avoid an invalid JSON error being returned from API.
